### PR TITLE
Fix: Implement user-friendly foreign key dropdowns and display

### DIFF
--- a/crud_generator/generators/view_generator.py
+++ b/crud_generator/generators/view_generator.py
@@ -27,9 +27,8 @@ def generate_view_index(table_name, columns, foreign_keys: list):
         is_fk_column = False
         for fk in foreign_keys:
             if fk['local_column'] == col['name']:
-                # Use the referenced table name and referenced column as header.
-                # This matches the alias generated in the model.
-                headers_list.append(f"                <th>{fk['referenced_table'].replace('_', ' ').title()} ({fk['referenced_column'].replace('_', ' ').title()})</th>")
+                # Use the referenced table name and display column as header.
+                headers_list.append(f"                <th>{fk['referenced_table'].replace('_', ' ').title()} ({fk['display_column'].replace('_', ' ').title()})</th>")
                 is_fk_column = True
                 break
         if not is_fk_column:
@@ -42,8 +41,8 @@ def generate_view_index(table_name, columns, foreign_keys: list):
         is_fk_column = False
         for fk in foreign_keys:
             if fk['local_column'] == col['name']:
-                # Access data using the alias generated in the model: referenced_table_referenced_column
-                alias = f"{fk['referenced_table']}_{fk['referenced_column']}"
+                # Access data using the alias generated in the model: referenced_table_display_column
+                alias = f"{fk['referenced_table']}_{fk['display_column']}"
                 rows_list.append(f"                        <td><?= htmlspecialchars($row['{alias}']) ?></td>")
                 is_fk_column = True
                 break
@@ -147,7 +146,7 @@ def generate_view_create(table_name, columns, foreign_keys: list) -> str:
                 <option value="">Seleccione un/a {label}</option>
                 <?php foreach (${referenced_table_name}s as ${referenced_table_name}_item): ?>
                     <option value="<?= htmlspecialchars(${referenced_table_name}_item['{referenced_id_column}']) ?>">
-                        <?= htmlspecialchars(${referenced_table_name}_item['{referenced_id_column}']) ?> </option>
+                        <?= htmlspecialchars(${referenced_table_name}_item['{fk_info['display_column']}']) ?> </option>
                 <?php endforeach; ?>
             </select>
         </div>"""
@@ -225,7 +224,7 @@ def generate_view_edit(table_name, columns, foreign_keys: list) -> str:
                 <?php foreach (${referenced_table_name}s as ${referenced_table_name}_item): ?>
                     <option value="<?= htmlspecialchars(${referenced_table_name}_item['{referenced_id_column}']) ?>"
                         <?= (${table_name}->{col['name']} == ${referenced_table_name}_item['{referenced_id_column}']) ? 'selected' : '' ?>>
-                        <?= htmlspecialchars(${referenced_table_name}_item['{referenced_id_column}']) ?> <!-- Adjust this to display a descriptive column if needed -->
+                        <?= htmlspecialchars(${referenced_table_name}_item['{fk_info['display_column']}']) ?>
                     </option>
                 <?php endforeach; ?>
             </select>


### PR DESCRIPTION
This commit resolves an issue where CRUD forms for tables with foreign keys were not displaying selectable options from the referenced tables correctly. Instead of showing IDs, they now show descriptive names.

Changes include:

1.  **SQLParser:**
    *   Enhanced to identify a suitable 'display_column' (e.g., 'name',
      'title') in referenced tables for foreign keys. This information
      is stored alongside the foreign key details.

2.  **ModelGenerator:**
    *   Updated to use the 'display_column' in the `readAll()` method's
      JOINs for more descriptive aliases.
    *   Modified helper methods (e.g., `getAllCategories()`) to fetch both
      the ID (for option value) and the 'display_column' (for option text)
      from referenced tables, ordered by the display column.
    *   Added a generic static `getAllFromTable()` method for flexibility.

3.  **ControllerGenerator:**
    *   Modified `create()` and `edit()` actions to call the specific model
      helper methods to fetch data for foreign key dropdowns.
    *   This data (ID and display name) is now correctly passed to the views.

4.  **ViewGenerator:**
    *   Updated `create.php` and `edit.php` templates to use the fetched
      'display_column' for the text of `<option>` elements in select
      dropdowns, while the ID remains the value.
    *   Updated `index.php` template to display the 'display_column' from
      related tables in the list view and adjusted table headers accordingly.

These changes ensure that the generated CRUD application provides a more intuitive user experience when dealing with related data.