### PR TITLE
Fix: Enhance SQL parser regex for foreign key detection flexibility

### DIFF
--- a/crud_generator/parser.py
+++ b/crud_generator/parser.py
@@ -110,7 +110,7 @@ class SQLParser:
             if line_to_process.strip().upper().startswith('FOREIGN KEY'):
                 # Attempt to parse it for FK details using the existing detailed regex
                 fk_match_detailed = re.match(
-                    r'FOREIGN\s+KEY\s*\([`"]?(\w+)[`"]?\)\s*REFERENCES\s*[`"]?(\w+)[`"]?\s*\([`"]?(\w+)[`"]?\)(?:\s*ON\s+DELETE\s+\w+)?(?:\s*ON\s+UPDATE\s+\w+)?',
+                    r'FOREIGN\s+KEY\s*\(\s*[`"]?(\w+)[`"]?\s*\)\s*REFERENCES\s+[`"]?(\w+)[`"]?\s*\(\s*[`"]?(\w+)[`"]?\s*\)(?:\s*ON\s+DELETE\s+\w+)?(?:\s*ON\s+UPDATE\s+\w+)?',
                     line_to_process,
                     re.IGNORECASE
                 )


### PR DESCRIPTION
This commit addresses the issue where dropdown menus for foreign keys were not being generated. The root cause was hypothesized to be the SQL parser's foreign key detection regex being too restrictive, failing to identify FK definitions even with minor spacing variations that are otherwise valid SQL.

Changes:

1.  **SQLParser (`parser.py`):**
    *   I modified the `fk_match_detailed` regular expression within the
      `parse_table_definition_content` method.
    *   The regex now allows for more flexible whitespace within the
      parentheses defining local and referenced columns (e.g., `( column_name )`
      as opposed to just `(column_name)`).
    *   This change increases the robustness of parsing standard SQL
      FOREIGN KEY clauses.

This correction should ensure that foreign keys are consistently identified, allowing the subsequent model, controller, and view generation steps to correctly create and populate the dropdown menus for foreign key fields in forms.